### PR TITLE
fix: parse stack cell from hex

### DIFF
--- a/packages/ton-adapter/src/tonapi-adapter.ts
+++ b/packages/ton-adapter/src/tonapi-adapter.ts
@@ -192,7 +192,10 @@ function TvmStackRecordToTupleItem(record: TvmStackRecord): TupleItem {
         case 'nan':
             return { type: 'nan' };
         case 'cell':
-            return { type: 'cell', cell: Cell.fromBase64(record.cell!) };
+            return {
+                type: 'cell',
+                cell: Cell.fromBoc(Buffer.from(record.cell!, 'hex'))[0]!
+            };
         case 'null':
             return { type: 'null' };
         case 'tuple':


### PR DESCRIPTION
Tonapi http API returns cells in a HEX representation. However, adapter tries to parse it as base64.